### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CI/CD](https://github.com/OCRG/ocrg.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/OCRG/ocrg.github.io/actions/workflows/deploy.yml)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/OCRG/ocrg.github.io?style=flat&cache=no)](https://github.com/OCRG/ocrg.github.io/releases)
-[![Release](https://img.shields.io/badge/Release-v0.0.2-blue.svg)](https://github.com/OCRG/ocrg.github.io/releases/tag/v0.0.2)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub issues](https://img.shields.io/github/issues/OCRG/ocrg.github.io)](https://github.com/OCRG/ocrg.github.io/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/OCRG/ocrg.github.io)](https://github.com/OCRG/ocrg.github.io/pulls)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # OCRG Documentation
 
 [![CI/CD](https://github.com/OCRG/ocrg.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/OCRG/ocrg.github.io/actions/workflows/deploy.yml)
-[![GitHub release (latest by date)](https://img.shields.io/github/v/release/OCRG/ocrg.github.io)](https://github.com/OCRG/ocrg.github.io/releases)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/OCRG/ocrg.github.io?style=flat&cache=no)](https://github.com/OCRG/ocrg.github.io/releases)
+[![Release](https://img.shields.io/badge/Release-v0.0.2-blue.svg)](https://github.com/OCRG/ocrg.github.io/releases/tag/v0.0.2)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub issues](https://img.shields.io/github/issues/OCRG/ocrg.github.io)](https://github.com/OCRG/ocrg.github.io/issues)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/OCRG/ocrg.github.io)](https://github.com/OCRG/ocrg.github.io/pulls)


### PR DESCRIPTION
## Changes

- Removed the hardcoded static release badge (v0.0.2)
- Kept only the dynamically updating badge that automatically displays the latest release version
- Added cache-busting parameters to ensure the badge always displays the current version

This change improves maintainability by eliminating the need to manually update the README with each new release.

## Testing
- Verified that the dynamic badge correctly displays the latest release version
- Confirmed the badge links to the GitHub releases page

This PR follows trunk-based development practices by making changes in a feature branch before merging to main.