### PR TITLE
Fix/changelog duplicate 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved button styling to match terminal theme
 - Enhanced visual hierarchy with consistent color scheme
 - Updated all internal links to use .html extension for use_directory_urls: false compatibility
-- Added 404 page to navigation menu
 - Updated link testing to enforce correct extensions based on use_directory_urls setting
 - Removed --strict flag from CI build to handle .html link extensions
 - Added documentation about link strategy in mkdocs.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Customized footer with OCRG branding, styled links, and terminal theme matching
-- Added custom 404 page with terminal theme styling
+- Added custom 404 page with terminal theme styling, updated components on 404 page
 
 ### Changed
 - Updated feature card styling with terminal theme colors and hover effects

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The built site will be in the `dist` directory.
 2. Create a new branch for your changes
 3. Make your changes
 4. Submit a pull request
+5. Important: **wait until all CI PASSES before requesting review.**
 
 ## License
 

--- a/docs/404.md
+++ b/docs/404.md
@@ -10,10 +10,6 @@ hide:
 </div>
 
 <div class="error-container">
-  <div class="placeholder-image purple">
-    <span>404 Error</span>
-    <small>Page not found in filesystem</small>
-  </div>
 
   <div class="error-actions">
     <a href="index.html" class="md-button md-button--primary">Return to Home</a>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ repo_url: https://github.com/OCRG/ocrg.github.io
 # to ensure consistent URL structure in production. This diverges from MkDocs'
 # default behavior but is necessary for our deployment setup.
 use_directory_urls: false
+not_found_page: 404.md
 
 theme:
   name: material
@@ -82,7 +83,6 @@ nav:
     - Contributing: documentation/contributing.md
   - Contact: contact.md
   - Donate: donate.md
-  - 404: 404.md
 
 plugins:
   - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,3 +91,4 @@ plugins:
 extra_css:
   - assets/stylesheets/extra.css
   - assets/stylesheets/banner.css
+


### PR DESCRIPTION
fix: configure 404 page properly

- Add `not_found_page: 404.md` to mkdocs.yml to properly handle 404 errors
- Remove duplicate 404 entry from changelog
- Keep 404 page out of navigation menu (it's a system page, not a nav item)