### PR TITLE
Chore/remove duplicate contribution docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated link testing to enforce correct extensions based on use_directory_urls setting
 - Removed --strict flag from CI build to handle .html link extensions
 - Added documentation about link strategy in mkdocs.yml
+- Consolidated contributing guidelines into single source of truth and updated README link
 
 ### Fixed
 - Restructured header override in `docs/overrides/main.html` to properly integrate the Tor banner using `{{ super() }}`. This resolves styling conflicts with the default theme header elements, particularly the GitHub repository link.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The built site will be in the `dist` directory.
 4. Submit a pull request
 5. Important: **wait until all CI PASSES before requesting review.**
 
+For detailed contributing guidelines, see our [Contributing Documentation](https://ocrg.github.io/documentation/contributing.html).
+
 ## License
 
 This documentation is licensed under the MIT License - see the LICENSE file for details.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -37,7 +37,7 @@
   <div class="md-footer-meta md-typeset" style="background-color: var(--ocrg-terminal-black); border-top: 1px solid var(--ocrg-terminal-border);">
     <div class="md-footer-meta__inner md-grid" style="padding: 1rem 0; display: flex; justify-content: center; align-items: center; width: 100%;">
       <div class="md-footer-copyright" style="color: var(--ocrg-text); text-align: center; font-size: 14px;">
-        Made with 💜 by <a href="https://github.com/OCRG" style="color: var(--ocrg-purple); text-decoration: underline;">OCRG</a> with <a href="https://www.mkdocs.org" style="color: var(--ocrg-purple); text-decoration: underline;">MkDocs</a>
+        Created with <a href="https://www.mkdocs.org" style="color: var(--ocrg-purple); text-decoration: underline;">MkDocs</a> and 💜 by <a href="https://github.com/OCRG/ocrg.github.io" style="color: var(--ocrg-purple); text-decoration: underline;">OCRG</a> 
       </div>
       {% if config.copyright %}
         <div class="md-footer-copyright" style="color: var(--ocrg-text); text-align: center; font-size: 14px;">


### PR DESCRIPTION
docs: consolidate contributing guidelines and update README link (fixes #26)

Consolidate contributing guidelines into a single source of truth in /docs/documentation/contributing.md and update README to link to it. This change reduces duplication, ensures consistency for contributors, and makes long-term maintenance easier. The contributing.md file now contains all generic contributing instructions while other files link to it instead of duplicating content.